### PR TITLE
fix: add justify text to layout blog list

### DIFF
--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-    <div class="container markdown top-pad">
+    <div class="container markdown top-pad has-content-justify">
         {{ .Content }}
     </div>
 


### PR DESCRIPTION
### :page_facing_up: Check difference images

Page: https://jucelio.dev/en-ca/blog/ and https://jucelio.dev/pt-br/blog/

---

<p align="center">BEFORE THE CHANGES</p>

![image](https://user-images.githubusercontent.com/10274274/119118992-22696c00-ba01-11eb-837b-b43bb40c9428.png)

<p align="center">AFTER THE CHANGES</p>

![image](https://user-images.githubusercontent.com/10274274/119119014-28f7e380-ba01-11eb-91d1-5dcd659621a5.png)
